### PR TITLE
Add relay_status

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -112,6 +112,10 @@ Relay.prototype.send = async function relay_send(data) {
 	this.ws.send(JSON.stringify(data))
 }
 
+Relay.prototype.status = function relay_status() {
+	return this.ws.readyState
+}
+
 function handle_nostr_message(relay, msg)
 {
 	let data


### PR DESCRIPTION
Easily accessed `ws.readyState` is useful in many situations.  Added this getter for my development purposes, maybe it aligns with your goals, passing it upstream. 