### PR TITLE
Convert camelcase to snake case for consistency

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -85,11 +85,11 @@ async function reconnect(me)
 	}
 }
 
-Relay.prototype.on = function relayOn(method, fn) {
+Relay.prototype.on = function relay_on(method, fn) {
 	this.onfn[method] = fn
 }
 
-Relay.prototype.close = function relayClose() {
+Relay.prototype.close = function relay_on() {
 	if (this.ws) {
 		this.manualClose = true
 		this.ws.close()

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -89,7 +89,7 @@ Relay.prototype.on = function relay_on(method, fn) {
 	this.onfn[method] = fn
 }
 
-Relay.prototype.close = function relay_on() {
+Relay.prototype.close = function relay_close() {
 	if (this.ws) {
 		this.manualClose = true
 		this.ws.close()


### PR DESCRIPTION
In `lib/relay` there were some functions that were camel case while your pattern was snake case. Converted to snake case. 