### PR TITLE
Enable function chaining for Relay.on

### DIFF
--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -27,6 +27,7 @@ RelayPool.prototype.on = function relayPoolOn(method, fn) {
 		this.onfn[method] = fn
 		relay.onfn[method] = fn.bind(null, relay)
 	}
+	return this
 }
 
 RelayPool.prototype.has = function relayPoolHas(relayUrl) {

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -37,8 +37,8 @@ function init_websocket(me) {
 	const ws = me.ws = new WS(me.url);
 	return new Promise((resolve, reject) => {
 		let resolved = false
-		ws.onmessage = (m) => { 
-			handle_nostr_message(me, m) 
+		ws.onmessage = (m) => {
+			handle_nostr_message(me, m)
 			if (me.onfn.message)
 				me.onfn.message(m)
 		}
@@ -91,6 +91,7 @@ async function reconnect(me)
 
 Relay.prototype.on = function relayOn(method, fn) {
 	this.onfn[method] = fn
+	return this
 }
 
 Relay.prototype.close = function relayClose() {


### PR DESCRIPTION
Simple change to enable common pattern with `on` methods.  Does not mandate chaining pattern, just supports it. Technically could be added to all methods for full coverage, but only added to `Relay.on` 

```
RelayPool(relays)
	.on('open', relay => {
		relay.subscribe("subid", {limit: 2, kinds:[1], authors: [jb55]})
	})
	.on('eose', relay => {
		relay.close()
	})
	.on('event', (relay, sub_id, ev) => {
		console.log(ev)
	})
```