### PR TITLE
Fix unhandled case of offline/invalid websocket reference

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -28,7 +28,12 @@ function Relay(relay, opts={})
 	const me = this
 	me.onfn = {}
 
-	init_websocket(me)
+	try {
+		init_websocket(me)
+	} catch(e) {
+		if (me.onfn.error)
+			me.onfn.error(e)
+	}
 
 	return this
 }


### PR DESCRIPTION
If a websocket is offline or invalid, previously `on.error` will never be called either because the error occurs during instantiation or because the setup is included in a promise. Added try/catch and patched into `onfn.error`. Maybe not the most elegant solution.