### PR TITLE
bugfix: event handler not set

### DIFF
--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -64,7 +64,7 @@ RelayPool.prototype.remove = function relayPoolRemove(url) {
 	for (const relay of this.relays) {
 		if (relay.url === url) {
 			relay.ws && relay.ws.close()
-			this.relays = this.replays.splice(i, 1)
+			this.relays = this.relays.splice(i, 1)
 			return true
 		}
 

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -68,17 +68,17 @@ RelayPool.prototype.remove = function relayPoolRemove(url) {
   return false;
 }
 
-RelayPool.prototype.subscribe = function relayPoolSubscribe(sub_id, filters, relay_ids) {
+RelayPool.prototype.subscribe = async function relayPoolSubscribe(sub_id, filters, relay_ids) {
 	const relays = relay_ids ? this.find_relays(relay_ids) : this.relays
 	for (const relay of relays) {
-		relay.subscribe(sub_id, filters)
+		await relay.subscribe(sub_id, filters)
 	}
 }
 
-RelayPool.prototype.unsubscribe = function relayPoolUnsubscibe(sub_id, relay_ids) {
+RelayPool.prototype.unsubscribe = async function relayPoolUnsubscibe(sub_id, relay_ids) {
 	const relays = relay_ids ? this.find_relays(relay_ids) : this.relays
 	for (const relay of relays) {
-		relay.unsubscribe(sub_id)
+		await relay.unsubscribe(sub_id)
 	}
 }
 

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -24,8 +24,8 @@ RelayPool.prototype.close = function relayPoolClose() {
 }
 
 RelayPool.prototype.on = function relayPoolOn(method, fn) {
+  this.onfn[method] = fn
 	for (const relay of this.relays) {
-		this.onfn[method] = fn
 		relay.onfn[method] = fn.bind(null, relay)
 	}
 	return this

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -59,19 +59,13 @@ RelayPool.prototype.setupHandlers = function relayPoolSetupHandlers()
 }
 
 RelayPool.prototype.remove = function relayPoolRemove(url) {
-	let i = 0
-
-	for (const relay of this.relays) {
-		if (relay.url === url) {
-			relay.ws && relay.ws.close()
-			this.relays = this.relays.splice(i, 1)
-			return true
-		}
-
-		i += 1
-	}
-
-	return false
+  const index = this.relays.findIndex( relay => relay.url === url );
+  if( index !== -1 ) {
+    this.relays[index].ws && this.relays[index].ws.close();
+    this.relays.splice(index, 1);
+    return true
+  }
+  return false;
 }
 
 RelayPool.prototype.subscribe = function relayPoolSubscribe(sub_id, filters, relay_ids) {

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -106,15 +106,15 @@ Relay.prototype.close = function relayClose() {
 	}
 }
 
-Relay.prototype.subscribe = function relay_subscribe(sub_id, filters) {
+Relay.prototype.subscribe = async function relay_subscribe(sub_id, filters) {
 	if (Array.isArray(filters))
-		this.send(["REQ", sub_id, ...filters])
+		await this.send(["REQ", sub_id, ...filters])
 	else
-		this.send(["REQ", sub_id, filters])
+		await this.send(["REQ", sub_id, filters])
 }
 
-Relay.prototype.unsubscribe = function relay_unsubscribe(sub_id) {
-	this.send(["CLOSE", sub_id])
+Relay.prototype.unsubscribe = async function relay_unsubscribe(sub_id) {
+	await this.send(["CLOSE", sub_id])
 }
 
 Relay.prototype.send = async function relay_send(data) {


### PR DESCRIPTION
when calling new new RelayPool([]) with empty relay list. the event handlers were not set, cause the setter was inside the loop. moved it out.