### PR TITLE
Fix typo

### DIFF
--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -64,7 +64,7 @@ RelayPool.prototype.remove = function relayPoolRemove(url) {
 	for (const relay of this.relays) {
 		if (relay.url === url) {
 			relay.ws && relay.ws.close()
-			this.relays = this.replays.splice(i, 1)
+			this.relays = this.relays.splice(i, 1)
 			return true
 		}
 


### PR DESCRIPTION
This typo breaks when calling `RelayPool.remove`