### PR TITLE
📝 Add typings

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function utf8_encode(txt) {
  * 
  * Calculate an id from an event
  * 
- * @param {Omit<NostREvent, "id">} ev 
+ * @param {Omit<NostREvent, "id" | "sig">} ev 
  */
 async function calculateId(ev) {
 	const commit = eventCommitment(ev)
@@ -72,7 +72,7 @@ async function calculateId(ev) {
 }
 
 /**
- * @param {Omit<NostREvent, "id">} ev 
+ * @param {Omit<NostREvent, "id" | "sig">} ev 
  */
 function eventCommitment(ev) {
 	const {pubkey,created_at,kind,tags,content} = ev

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function utf8_encode(txt) {
  * 
  * Calculate an id from an event
  * 
- * @param {NostREvent} ev 
+ * @param {Omit<NostREvent, "id">} ev 
  */
 async function calculateId(ev) {
 	const commit = eventCommitment(ev)
@@ -72,7 +72,7 @@ async function calculateId(ev) {
 }
 
 /**
- * @param {NostREvent} ev 
+ * @param {Omit<NostREvent, "id">} ev 
  */
 function eventCommitment(ev) {
 	const {pubkey,created_at,kind,tags,content} = ev

--- a/index.js
+++ b/index.js
@@ -4,14 +4,49 @@ const RelayPool = require('./lib/relay-pool')
 const noble = require('noble-secp256k1')
 const crypto = require('crypto')
 
+/**
+ * See https://github.com/nostr-protocol/nips/blob/master/01.md for definition of NostREvent
+ * @typedef {Object} NostREvent
+ * @property {string} id - 32-bytes lowercase hex-encoded sha256 of the serialized event data
+ * @property {string} pubkey - 32-bytes lowercase hex-encoded public key of the event creator
+ * @property {number} created_at - unix timestamp in seconds
+ * @property {number} kind - event kind, see https://github.com/nostr-protocol/nips/blob/master/01.md#basic-event-kinds
+ * @property {Array<string[]>} tags
+ * @property {string} content
+ * @property {string} sig - 64-bytes lowercase hex-encoded schnorr signature of the event id
+ */
+
+/**
+ * @typedef {Object} NostRDelegation
+ * @property {string} pubkey - 32-bytes lowercase hex-encoded public key of the event creator
+ * @property {string} publisherPubkey - 32-bytes lowercase hex-encoded public key of the event creator
+ * @property {string} conditions - &` separated set of event creation permissions that the delegate is required to adhere to when creating events. eg: `created_at>1669303873&created_at<1674574279&kind=1,7`
+ * @property {string} token - 64-bytes lowercase hex-encoded schnorr signature of the delegation commitment
+ */
+
+/**
+ * Create a signature for an id
+ * 
+ * @param {string} privkey 
+ * @param {string} id 
+ */
 async function signId(privkey, id) {
 	return await noble.schnorr.sign(id, privkey)
 }
 
+/**
+ * Verify an event
+ * 
+ * @param {NostREvent} event 
+ * @returns true if valid signature, false otherwise
+ */
 async function verifyEvent(event) {
 	return await noble.schnorr.verify(event.sig, event.id, event.pubkey)
 }
 
+/**
+ * @param {string} txt 
+ */
 function utf8_encode(txt) {
 	if (typeof TextEncoder !== 'undefined' && TextEncoder) {
 		const encoder = new TextEncoder()
@@ -23,6 +58,12 @@ function utf8_encode(txt) {
 	}
 }
 
+/**
+ * 
+ * Calculate an id from an event
+ * 
+ * @param {NostREvent} ev 
+ */
 async function calculateId(ev) {
 	const commit = eventCommitment(ev)
 	const sha256 = noble.utils.sha256;
@@ -30,21 +71,45 @@ async function calculateId(ev) {
 	return hexEncode(await sha256(buf))
 }
 
+/**
+ * @param {NostREvent} ev 
+ */
 function eventCommitment(ev) {
 	const {pubkey,created_at,kind,tags,content} = ev
 	return JSON.stringify([0, pubkey, created_at, kind, tags, content])
 }
 
+/**
+ * @param {string} pk
+ * @param {string} conditions 
+ */
 function delegationCommitment(pk, conditions) {
 	return `nostr:delegation:${pk}:${conditions}`
 }
 
+/**
+ * Sign a delegation string in the form `nostr:delegation:...`.
+ * 
+ * @param {string} privkey 
+ * @param {string} unsigned_token 
+ * @returns a signature string called the delegation token
+ */
 async function signDelegationToken(privkey, unsigned_token) 
 {
 	const hash = hexEncode(await noble.utils.sha256(unsigned_token))
 	return (await signId(privkey, hash))
 }
 
+/**
+ * Create a delegation. This gives `publisherPubkey` permission to create events
+on the `privkey`s behalf subject to `conditions`
+ *
+ * @param {string} privkey 
+ * @param {string} publisherPubkey 
+ * @param {NostRDelegation["conditions"]} conditions &` separated set of event creation permissions that the delegate
+is required to adhere to when creating events. eg: `created_at>1669303873&created_at<1674574279&kind=1,7` 
+ * @returns {Promise<NostRDelegation>}
+ */
 async function createDelegation(privkey, publisherPubkey, conditions) {
 	const pubkey = getPublicKey(privkey)
 	const unsigned_token = delegationCommitment(publisherPubkey, conditions)
@@ -52,14 +117,21 @@ async function createDelegation(privkey, publisherPubkey, conditions) {
 	return {pubkey, publisherPubkey, conditions, token}
 }
 
+/**
+ * @param {NostRDelegation} delegation 
+ * @returns {["delegation", string, string, string]}
+ */
 function createDelegationTag(delegation) {
 	const { pubkey, conditions, token } = delegation
 	return ["delegation", pubkey, conditions, token]
 }
 
+/**
+ * @param {Array<string[]>} tags 
+ * @param {NostRDelegation} delegation 
+ */
 function upsert_delegation_tag(tags, delegation)
 {
-	let found = false
 	for (const tag of tags) {
 		if (tag.length >= 4 && tag[0] === "delegation") {
 			tag[1] = delegation.pubkey
@@ -71,6 +143,15 @@ function upsert_delegation_tag(tags, delegation)
 	tags.push(createDelegationTag(delegation))
 }
 
+/**
+ * Create a delegated event from {@link delegation}. This is an event posted on behalf
+of `delegation.pubkey` subject to `delegation.conditions`.
+ *
+ * @param {string} publisher_privkey the private key of the delegate, the entity posting on behalf of `delegation.pubkey`
+ * @param {NostREvent} ev The event to post as a delegate. The event's `pubkey` will be overridden by the `publisherPubkey`. The delegation tag will be upserted into the tag list.
+ * @param {{pubkey: string, conditions: string, token: string}} delegation a delegation in the form returned by {@link createDelegation}
+ * @returns 
+ */
 async function createDelegationEvent(publisher_privkey, ev, delegation) {
 	let tags = ev.tags || []
 
@@ -83,6 +164,10 @@ async function createDelegationEvent(publisher_privkey, ev, delegation) {
 	return ev
 }
 
+/**
+ * Convert 0-15 to 0-F
+ * @param {number} val 
+ */
 function hexChar(val) {
 	if (val < 10)
 		return String.fromCharCode(48 + val)
@@ -90,6 +175,9 @@ function hexChar(val) {
 		return String.fromCharCode(97 + val - 10)
 }
 
+/**
+ * @param {Uint8Array} buf 
+ */
 function hexEncode(buf) {
 	let str = ""
 	for (let i = 0; i < buf.length; i++) {
@@ -100,6 +188,9 @@ function hexEncode(buf) {
 	return str
 }
 
+/**
+ * @param {string} str 
+ */
 function base64_decode(str)
 {
 	if (typeof Buffer !== 'undefined' && Buffer) {
@@ -110,7 +201,15 @@ function base64_decode(str)
 	throw new Error("no base64 implementation")
 }
 
-
+/**
+ * Encrypt a direct message
+ *
+ * @param {string} privkey 
+ * @param {string} to 
+ * @param {string} msg 
+ * 
+ * @returns encrypted message content
+ */
 function encryptDm(privkey, to, msg) {
 	const shared_point = noble.getSharedSecret(privkey, '02' + to)
 	const shared_x = shared_point.substr(2, 64)
@@ -127,6 +226,13 @@ function encryptDm(privkey, to, msg) {
 	return encrypted + "?iv=" + iv.toString('base64')
 }
 
+/**
+ * Decrypt a direct message
+ * 
+ * @param {string} privkey 
+ * @param {NostREvent} ev 
+ * @returns decrypted message content
+ */
 function decryptDm(privkey, ev) {
 	let [enc, iv] = ev.content.split("?")
 	if (!iv || !enc)
@@ -148,7 +254,11 @@ function decryptDm(privkey, ev) {
 	return decrypted
 }
 
-
+/**
+ * Get a public key from a privkey
+ *
+ * @param {string} privkey 
+ */
 function getPublicKey(privkey) {
 	return noble.schnorr.getPublicKey(privkey)
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 const Relay = require('./lib/relay')
 const RelayPool = require('./lib/relay-pool')
 const noble = require('noble-secp256k1')
@@ -149,8 +148,7 @@ of `delegation.pubkey` subject to `delegation.conditions`.
  *
  * @param {string} publisher_privkey the private key of the delegate, the entity posting on behalf of `delegation.pubkey`
  * @param {NostREvent} ev The event to post as a delegate. The event's `pubkey` will be overridden by the `publisherPubkey`. The delegation tag will be upserted into the tag list.
- * @param {{pubkey: string, conditions: string, token: string}} delegation a delegation in the form returned by {@link createDelegation}
- * @returns 
+ * @param {NostRDelegation} delegation a delegation in the form returned by {@link createDelegation}
  */
 async function createDelegationEvent(publisher_privkey, ev, delegation) {
 	let tags = ev.tags || []

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -1,12 +1,26 @@
 
 const Relay = require('./relay')
 
+/**
+ * @class RelayPool
+ * @classdesc Connect to a pool of relays. You should use this instead of `Relay` directly.
+ * @param {string[]} relays 
+ * @param {{reconnect?: boolean} | undefined} opts 
+ * 
+ * @example ```
+const relays = [`wss://relay1.com`, `wss://relay2.com`]
+const pool = RelayPool(relays, {reconnect: false})
+```
+ */
 function RelayPool(relays, opts)
 {
 	if (!(this instanceof RelayPool))
 		return new RelayPool(relays, opts)
 
 	this.onfn = {}
+	/**
+	 * @type {Relay[]}
+	 */
 	this.relays = []
 	this.opts = opts
 
@@ -23,6 +37,11 @@ RelayPool.prototype.close = function relayPoolClose() {
 	}
 }
 
+/**
+ * @param {"message"|"close"|"error"|"open"|"ok"|"event"|"eose"|"notice"} method 
+ * @param {(relay: Relay, ...data: any[]) => unknown} fn 
+ * @returns 
+ */
 RelayPool.prototype.on = function relayPoolOn(method, fn) {
 	for (const relay of this.relays) {
 		this.onfn[method] = fn
@@ -31,6 +50,9 @@ RelayPool.prototype.on = function relayPoolOn(method, fn) {
 	return this
 }
 
+/**
+ * @param {string} relayUrl 
+ */
 RelayPool.prototype.has = function relayPoolHas(relayUrl) {
 	for (const relay of this.relays) {
 		if (relay.url === relayUrl)
@@ -40,6 +62,11 @@ RelayPool.prototype.has = function relayPoolHas(relayUrl) {
 	return false
 }
 
+/**
+ * 
+ * @param {*} payload 
+ * @param {*} relay_ids 
+ */
 RelayPool.prototype.send = function relayPoolSend(payload, relay_ids) {
 	const relays = relay_ids ? this.find_relays(relay_ids) : this.relays
 	for (const relay of relays) {
@@ -58,6 +85,9 @@ RelayPool.prototype.setupHandlers = function relayPoolSetupHandlers()
 	}
 }
 
+/**
+ * @param {string} url 
+ */
 RelayPool.prototype.remove = function relayPoolRemove(url) {
 	let i = 0
 
@@ -74,6 +104,11 @@ RelayPool.prototype.remove = function relayPoolRemove(url) {
 	return false
 }
 
+/**
+ * @param {string} sub_id 
+ * @param {string | string[]} filters 
+ * @param {string[]} relay_ids 
+ */
 RelayPool.prototype.subscribe = function relayPoolSubscribe(sub_id, filters, relay_ids) {
 	const relays = relay_ids ? this.find_relays(relay_ids) : this.relays
 	for (const relay of relays) {
@@ -81,6 +116,11 @@ RelayPool.prototype.subscribe = function relayPoolSubscribe(sub_id, filters, rel
 	}
 }
 
+/**
+ * 
+ * @param {string} sub_id 
+ * @param {string[] | undefined} relay_ids unscubscribe from all relays if undefined 
+ */
 RelayPool.prototype.unsubscribe = function relayPoolUnsubscibe(sub_id, relay_ids) {
 	const relays = relay_ids ? this.find_relays(relay_ids) : this.relays
 	for (const relay of relays) {
@@ -88,7 +128,10 @@ RelayPool.prototype.unsubscribe = function relayPoolUnsubscibe(sub_id, relay_ids
 	}
 }
 
-
+/**
+ * @param {Relay | string} relay 
+ * @returns {boolean} true if relay was added, false if it already exists
+ */
 RelayPool.prototype.add = function relayPoolAdd(relay) {
 	if (relay instanceof Relay) {
 		if (this.has(relay.url))
@@ -108,6 +151,11 @@ RelayPool.prototype.add = function relayPoolAdd(relay) {
 	return true
 }
 
+/**
+ * 
+ * @param {string[]} relay_ids 
+ * @returns {Relay[]}
+ */
 RelayPool.prototype.find_relays = function relayPoolFindRelays(relay_ids) {
 	if (relay_ids instanceof Relay)
 		return [relay_ids]
@@ -116,16 +164,16 @@ RelayPool.prototype.find_relays = function relayPoolFindRelays(relay_ids) {
 		return []
 
 	if (!relay_ids[0])
-		throw new Error("what!?")
+		throw new TypeError("Empty array passed to find_relays")
 
-	if (relay_ids[0] instanceof Relay)
-		return relay_ids
-
-	return this.relays.reduce((acc, relay) => {
-		if (relay_ids.some((rid) => relay.url === rid))
-			acc.push(relay)
-		return acc
-	}, [])
+	return [].concat(
+		relay_ids.filter(relay => relay instanceof Relay), 
+		this.relays.reduce((acc, relay) => {
+			if (relay_ids.some((rid) => relay.url === rid))
+				acc.push(relay)
+			return acc
+		}, [])
+	)
 }
 
 module.exports = RelayPool

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -64,8 +64,8 @@ RelayPool.prototype.has = function relayPoolHas(relayUrl) {
 
 /**
  * 
- * @param {*} payload 
- * @param {*} relay_ids 
+ * @param {unknown} payload 
+ * @param {string[] | undefined} relay_ids 
  */
 RelayPool.prototype.send = function relayPoolSend(payload, relay_ids) {
 	const relays = relay_ids ? this.find_relays(relay_ids) : this.relays

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -5,7 +5,7 @@ const Relay = require('./relay')
  * @class RelayPool
  * @classdesc Connect to a pool of relays. You should use this instead of `Relay` directly.
  * @param {string[]} relays 
- * @param {{reconnect?: boolean} | undefined} opts 
+ * @param {{reconnect?: boolean}} [opts] 
  * 
  * @example ```
 const relays = [`wss://relay1.com`, `wss://relay2.com`]
@@ -65,7 +65,7 @@ RelayPool.prototype.has = function relayPoolHas(relayUrl) {
 /**
  * 
  * @param {unknown} payload 
- * @param {string[] | undefined} relay_ids 
+ * @param {string[]} [relay_ids] 
  */
 RelayPool.prototype.send = function relayPoolSend(payload, relay_ids) {
 	const relays = relay_ids ? this.find_relays(relay_ids) : this.relays
@@ -107,7 +107,7 @@ RelayPool.prototype.remove = function relayPoolRemove(url) {
 /**
  * @param {string} sub_id 
  * @param {string | string[]} filters 
- * @param {string[]} relay_ids 
+ * @param {string[]} [relay_ids] 
  */
 RelayPool.prototype.subscribe = function relayPoolSubscribe(sub_id, filters, relay_ids) {
 	const relays = relay_ids ? this.find_relays(relay_ids) : this.relays
@@ -119,7 +119,7 @@ RelayPool.prototype.subscribe = function relayPoolSubscribe(sub_id, filters, rel
 /**
  * 
  * @param {string} sub_id 
- * @param {string[] | undefined} relay_ids unscubscribe from all relays if undefined 
+ * @param {string[]} [relay_ids] unscubscribe from all relays if undefined 
  */
 RelayPool.prototype.unsubscribe = function relayPoolUnsubscibe(sub_id, relay_ids) {
 	const relays = relay_ids ? this.find_relays(relay_ids) : this.relays

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -16,7 +16,7 @@ Relay.prototype.wait_connected = async function relay_wait_connected() {
 /**
  * @classdesc Connect to a relay server and subscribe to events.
  * @param {string} relay 
- * @param {{reconnect?: boolean} | undefined} opts 
+ * @param {{reconnect?: boolean}} [opts] 
  * @class Relay
  */
 function Relay(relay, opts={})

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -1,6 +1,6 @@
 const WS = typeof WebSocket !== 'undefined' ? WebSocket : require('ws')
 
-Relay.prototype.wait_connected = async function relay_wait_connected(data) {
+Relay.prototype.wait_connected = async function relay_wait_connected() {
 	let retry = 1000
 	while (true) {
 		if (this.ws.readyState !== 1) {
@@ -13,7 +13,12 @@ Relay.prototype.wait_connected = async function relay_wait_connected(data) {
 	}
 }
 
-
+/**
+ * @classdesc Connect to a relay server and subscribe to events.
+ * @param {string} relay 
+ * @param {{reconnect?: boolean} | undefined} opts 
+ * @class Relay
+ */
 function Relay(relay, opts={})
 {
 	if (!(this instanceof Relay))
@@ -37,6 +42,10 @@ function Relay(relay, opts={})
 	return this
 }
 
+/**
+ * @param {Relay} me 
+ * @returns {Promise<Relay>}
+ */
 function init_websocket(me) {
 	return new Promise((resolve, reject) => {
 		const ws = me.ws = new WS(me.url);
@@ -75,13 +84,20 @@ function init_websocket(me) {
 	});
 }
 
+/**
+ * @param {number} ms 
+ * @returns {Promise<void>}
+ */
 function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+	return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/**
+ * 
+ * @param {Relay} me 
+ */
 async function reconnect(me)
 {
-	const reconnecting = true
 	let n = 100
 	try {
 		me.reconnecting = true
@@ -94,6 +110,12 @@ async function reconnect(me)
 	}
 }
 
+/**
+ * 
+ * @param {"message"|"close"|"error"|"open"|"ok"|"event"|"eose"|"notice"} method 
+ * @param {(...data: any[]) => unknown} fn 
+ * @returns 
+ */
 Relay.prototype.on = function relayOn(method, fn) {
 	this.onfn[method] = fn
 	return this
@@ -106,6 +128,10 @@ Relay.prototype.close = function relayClose() {
 	}
 }
 
+/**
+ * @param {string} sub_id 
+ * @param {string | string[]} filters 
+ */
 Relay.prototype.subscribe = function relay_subscribe(sub_id, filters) {
 	if (Array.isArray(filters))
 		this.send(["REQ", sub_id, ...filters])
@@ -113,15 +139,26 @@ Relay.prototype.subscribe = function relay_subscribe(sub_id, filters) {
 		this.send(["REQ", sub_id, filters])
 }
 
+/**
+ * @param {string} sub_id 
+ */
 Relay.prototype.unsubscribe = function relay_unsubscribe(sub_id) {
 	this.send(["CLOSE", sub_id])
 }
 
+/**
+ * 
+ * @param {unknown} data 
+ */
 Relay.prototype.send = async function relay_send(data) {
 	await this.wait_connected()
 	this.ws.send(JSON.stringify(data))
 }
 
+/**
+ * @param {Relay} relay 
+ * @param {{data: unknown[]}} msg 
+ */
 function handle_nostr_message(relay, msg)
 {
 	let data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "nostr",
-  "version": "0.1.0",
+  "version": "0.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nostr",
-      "version": "0.1.0",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "noble-secp256k1": "^1.2.14",
         "ws": "^8.8.1"
       },
       "devDependencies": {
-        "tape": "^5.6.0"
+        "tape": "^5.6.0",
+        "typescript": "^5.0.4"
       }
     },
     "node_modules/array.prototype.every": {
@@ -921,6 +922,19 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "node_modules/typescript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -1677,6 +1691,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.2.8",
   "description": "nostr lib and cli",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "scripts": {
-    "test": "tape test/*.js"
+    "test": "tape test/*.js",
+    "prepublish": "npx -p typescript tsc index.js lib/*.js --outDir types --declaration --allowJs --emitDeclarationOnly"
   },
   "repository": {
     "type": "git",
@@ -23,7 +25,8 @@
   },
   "homepage": "https://github.com/jb55/nostr-js",
   "devDependencies": {
-    "tape": "^5.6.0"
+    "tape": "^5.6.0",
+    "typescript": "^5.0.4"
   },
   "dependencies": {
     "noble-secp256k1": "^1.2.14",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -81,9 +81,9 @@ export function verifyEvent(event: NostREvent): Promise<boolean>;
  *
  * Calculate an id from an event
  *
- * @param {NostREvent} ev
+ * @param {Omit<NostREvent, "id">} ev
  */
-export function calculateId(ev: NostREvent): Promise<string>;
+export function calculateId(ev: Omit<NostREvent, "id">): Promise<string>;
 /**
  * Get a public key from a privkey
  *
@@ -152,7 +152,7 @@ export function createDelegation(privkey: string, publisherPubkey: string, condi
  */
 export function signDelegationToken(privkey: string, unsigned_token: string): Promise<string>;
 /**
- * @param {NostREvent} ev
+ * @param {Omit<NostREvent, "id">} ev
  */
-export function eventCommitment(ev: NostREvent): string;
+export function eventCommitment(ev: Omit<NostREvent, "id">): string;
 export { Relay, RelayPool };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -81,9 +81,9 @@ export function verifyEvent(event: NostREvent): Promise<boolean>;
  *
  * Calculate an id from an event
  *
- * @param {Omit<NostREvent, "id">} ev
+ * @param {Omit<NostREvent, "id" | "sig">} ev
  */
-export function calculateId(ev: Omit<NostREvent, "id">): Promise<string>;
+export function calculateId(ev: Omit<NostREvent, "id" | "sig">): Promise<string>;
 /**
  * Get a public key from a privkey
  *
@@ -152,7 +152,7 @@ export function createDelegation(privkey: string, publisherPubkey: string, condi
  */
 export function signDelegationToken(privkey: string, unsigned_token: string): Promise<string>;
 /**
- * @param {Omit<NostREvent, "id">} ev
+ * @param {Omit<NostREvent, "id" | "sig">} ev
  */
-export function eventCommitment(ev: Omit<NostREvent, "id">): string;
+export function eventCommitment(ev: Omit<NostREvent, "id" | "sig">): string;
 export { Relay, RelayPool };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -124,14 +124,9 @@ of `delegation.pubkey` subject to `delegation.conditions`.
  *
  * @param {string} publisher_privkey the private key of the delegate, the entity posting on behalf of `delegation.pubkey`
  * @param {NostREvent} ev The event to post as a delegate. The event's `pubkey` will be overridden by the `publisherPubkey`. The delegation tag will be upserted into the tag list.
- * @param {{pubkey: string, conditions: string, token: string}} delegation a delegation in the form returned by {@link createDelegation}
- * @returns
+ * @param {NostRDelegation} delegation a delegation in the form returned by {@link createDelegation}
  */
-export function createDelegationEvent(publisher_privkey: string, ev: NostREvent, delegation: {
-    pubkey: string;
-    conditions: string;
-    token: string;
-}): Promise<NostREvent>;
+export function createDelegationEvent(publisher_privkey: string, ev: NostREvent, delegation: NostRDelegation): Promise<NostREvent>;
 /**
  * Create a delegation. This gives `publisherPubkey` permission to create events
 on the `privkey`s behalf subject to `conditions`

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,158 @@
+/**
+ * See https://github.com/nostr-protocol/nips/blob/master/01.md for definition of NostREvent
+ */
+export type NostREvent = {
+    /**
+     * - 32-bytes lowercase hex-encoded sha256 of the serialized event data
+     */
+    id: string;
+    /**
+     * - 32-bytes lowercase hex-encoded public key of the event creator
+     */
+    pubkey: string;
+    /**
+     * - unix timestamp in seconds
+     */
+    created_at: number;
+    /**
+     * - event kind, see https://github.com/nostr-protocol/nips/blob/master/01.md#basic-event-kinds
+     */
+    kind: number;
+    tags: Array<string[]>;
+    content: string;
+    /**
+     * - 64-bytes lowercase hex-encoded schnorr signature of the event id
+     */
+    sig: string;
+};
+export type NostRDelegation = {
+    /**
+     * - 32-bytes lowercase hex-encoded public key of the event creator
+     */
+    pubkey: string;
+    /**
+     * - 32-bytes lowercase hex-encoded public key of the event creator
+     */
+    publisherPubkey: string;
+    /**
+     * - &` separated set of event creation permissions that the delegate is required to adhere to when creating events. eg: `created_at>1669303873&created_at<1674574279&kind=1,7`
+     */
+    conditions: string;
+    /**
+     * - 64-bytes lowercase hex-encoded schnorr signature of the delegation commitment
+     */
+    token: string;
+};
+import Relay = require("./lib/relay");
+import RelayPool = require("./lib/relay-pool");
+/**
+ * See https://github.com/nostr-protocol/nips/blob/master/01.md for definition of NostREvent
+ * @typedef {Object} NostREvent
+ * @property {string} id - 32-bytes lowercase hex-encoded sha256 of the serialized event data
+ * @property {string} pubkey - 32-bytes lowercase hex-encoded public key of the event creator
+ * @property {number} created_at - unix timestamp in seconds
+ * @property {number} kind - event kind, see https://github.com/nostr-protocol/nips/blob/master/01.md#basic-event-kinds
+ * @property {Array<string[]>} tags
+ * @property {string} content
+ * @property {string} sig - 64-bytes lowercase hex-encoded schnorr signature of the event id
+ */
+/**
+ * @typedef {Object} NostRDelegation
+ * @property {string} pubkey - 32-bytes lowercase hex-encoded public key of the event creator
+ * @property {string} publisherPubkey - 32-bytes lowercase hex-encoded public key of the event creator
+ * @property {string} conditions - &` separated set of event creation permissions that the delegate is required to adhere to when creating events. eg: `created_at>1669303873&created_at<1674574279&kind=1,7`
+ * @property {string} token - 64-bytes lowercase hex-encoded schnorr signature of the delegation commitment
+ */
+/**
+ * Create a signature for an id
+ *
+ * @param {string} privkey
+ * @param {string} id
+ */
+export function signId(privkey: string, id: string): Promise<string>;
+/**
+ * Verify an event
+ *
+ * @param {NostREvent} event
+ * @returns true if valid signature, false otherwise
+ */
+export function verifyEvent(event: NostREvent): Promise<boolean>;
+/**
+ *
+ * Calculate an id from an event
+ *
+ * @param {NostREvent} ev
+ */
+export function calculateId(ev: NostREvent): Promise<string>;
+/**
+ * Get a public key from a privkey
+ *
+ * @param {string} privkey
+ */
+export function getPublicKey(privkey: string): string;
+/**
+ * Decrypt a direct message
+ *
+ * @param {string} privkey
+ * @param {NostREvent} ev
+ * @returns decrypted message content
+ */
+export function decryptDm(privkey: string, ev: NostREvent): any;
+/**
+ * Encrypt a direct message
+ *
+ * @param {string} privkey
+ * @param {string} to
+ * @param {string} msg
+ *
+ * @returns encrypted message content
+ */
+export function encryptDm(privkey: string, to: string, msg: string): string;
+/**
+ * @param {string} pk
+ * @param {string} conditions
+ */
+export function delegationCommitment(pk: string, conditions: string): string;
+/**
+ * @param {NostRDelegation} delegation
+ * @returns {["delegation", string, string, string]}
+ */
+export function createDelegationTag(delegation: NostRDelegation): ["delegation", string, string, string];
+/**
+ * Create a delegated event from {@link delegation}. This is an event posted on behalf
+of `delegation.pubkey` subject to `delegation.conditions`.
+ *
+ * @param {string} publisher_privkey the private key of the delegate, the entity posting on behalf of `delegation.pubkey`
+ * @param {NostREvent} ev The event to post as a delegate. The event's `pubkey` will be overridden by the `publisherPubkey`. The delegation tag will be upserted into the tag list.
+ * @param {{pubkey: string, conditions: string, token: string}} delegation a delegation in the form returned by {@link createDelegation}
+ * @returns
+ */
+export function createDelegationEvent(publisher_privkey: string, ev: NostREvent, delegation: {
+    pubkey: string;
+    conditions: string;
+    token: string;
+}): Promise<NostREvent>;
+/**
+ * Create a delegation. This gives `publisherPubkey` permission to create events
+on the `privkey`s behalf subject to `conditions`
+ *
+ * @param {string} privkey
+ * @param {string} publisherPubkey
+ * @param {NostRDelegation["conditions"]} conditions &` separated set of event creation permissions that the delegate
+is required to adhere to when creating events. eg: `created_at>1669303873&created_at<1674574279&kind=1,7`
+ * @returns {Promise<NostRDelegation>}
+ */
+export function createDelegation(privkey: string, publisherPubkey: string, conditions: NostRDelegation["conditions"]): Promise<NostRDelegation>;
+/**
+ * Sign a delegation string in the form `nostr:delegation:...`.
+ *
+ * @param {string} privkey
+ * @param {string} unsigned_token
+ * @returns a signature string called the delegation token
+ */
+export function signDelegationToken(privkey: string, unsigned_token: string): Promise<string>;
+/**
+ * @param {NostREvent} ev
+ */
+export function eventCommitment(ev: NostREvent): string;
+export { Relay, RelayPool };

--- a/types/lib/relay-pool.d.ts
+++ b/types/lib/relay-pool.d.ts
@@ -49,10 +49,10 @@ declare class RelayPool {
     has(relayUrl: string): boolean;
     /**
      *
-     * @param {*} payload
-     * @param {*} relay_ids
+     * @param {unknown} payload
+     * @param {string[] | undefined} relay_ids
      */
-    send(payload: any, relay_ids: any): void;
+    send(payload: unknown, relay_ids: string[] | undefined): void;
     setupHandlers(): void;
     /**
      * @param {string} url

--- a/types/lib/relay-pool.d.ts
+++ b/types/lib/relay-pool.d.ts
@@ -1,0 +1,85 @@
+export = RelayPool;
+/**
+ * @class RelayPool
+ * @classdesc Connect to a pool of relays. You should use this instead of `Relay` directly.
+ * @param {string[]} relays
+ * @param {{reconnect?: boolean} | undefined} opts
+ *
+ * @example ```
+const relays = [`wss://relay1.com`, `wss://relay2.com`]
+const pool = RelayPool(relays, {reconnect: false})
+```
+ */
+declare function RelayPool(relays: string[], opts: {
+    reconnect?: boolean;
+} | undefined): RelayPool;
+declare class RelayPool {
+    /**
+     * @class RelayPool
+     * @classdesc Connect to a pool of relays. You should use this instead of `Relay` directly.
+     * @param {string[]} relays
+     * @param {{reconnect?: boolean} | undefined} opts
+     *
+     * @example ```
+    const relays = [`wss://relay1.com`, `wss://relay2.com`]
+    const pool = RelayPool(relays, {reconnect: false})
+    ```
+     */
+    constructor(relays: string[], opts: {
+        reconnect?: boolean;
+    } | undefined);
+    onfn: {};
+    /**
+     * @type {Relay[]}
+     */
+    relays: Relay[];
+    opts: {
+        reconnect?: boolean;
+    };
+    close(): void;
+    /**
+     * @param {"message"|"close"|"error"|"open"|"ok"|"event"|"eose"|"notice"} method
+     * @param {(relay: Relay, ...data: any[]) => unknown} fn
+     * @returns
+     */
+    on(method: "message" | "close" | "error" | "open" | "ok" | "event" | "eose" | "notice", fn: (relay: Relay, ...data: any[]) => unknown): RelayPool;
+    /**
+     * @param {string} relayUrl
+     */
+    has(relayUrl: string): boolean;
+    /**
+     *
+     * @param {*} payload
+     * @param {*} relay_ids
+     */
+    send(payload: any, relay_ids: any): void;
+    setupHandlers(): void;
+    /**
+     * @param {string} url
+     */
+    remove(url: string): boolean;
+    /**
+     * @param {string} sub_id
+     * @param {string | string[]} filters
+     * @param {string[]} relay_ids
+     */
+    subscribe(sub_id: string, filters: string | string[], relay_ids: string[]): void;
+    /**
+     *
+     * @param {string} sub_id
+     * @param {string[] | undefined} relay_ids unscubscribe from all relays if undefined
+     */
+    unsubscribe(sub_id: string, relay_ids: string[] | undefined): void;
+    /**
+     * @param {Relay | string} relay
+     * @returns {boolean} true if relay was added, false if it already exists
+     */
+    add(relay: Relay | string): boolean;
+    /**
+     *
+     * @param {string[]} relay_ids
+     * @returns {Relay[]}
+     */
+    find_relays(relay_ids: string[]): Relay[];
+}
+import Relay = require("./relay");

--- a/types/lib/relay-pool.d.ts
+++ b/types/lib/relay-pool.d.ts
@@ -3,31 +3,31 @@ export = RelayPool;
  * @class RelayPool
  * @classdesc Connect to a pool of relays. You should use this instead of `Relay` directly.
  * @param {string[]} relays
- * @param {{reconnect?: boolean} | undefined} opts
+ * @param {{reconnect?: boolean}} [opts]
  *
  * @example ```
 const relays = [`wss://relay1.com`, `wss://relay2.com`]
 const pool = RelayPool(relays, {reconnect: false})
 ```
  */
-declare function RelayPool(relays: string[], opts: {
+declare function RelayPool(relays: string[], opts?: {
     reconnect?: boolean;
-} | undefined): RelayPool;
+}): RelayPool;
 declare class RelayPool {
     /**
      * @class RelayPool
      * @classdesc Connect to a pool of relays. You should use this instead of `Relay` directly.
      * @param {string[]} relays
-     * @param {{reconnect?: boolean} | undefined} opts
+     * @param {{reconnect?: boolean}} [opts]
      *
      * @example ```
     const relays = [`wss://relay1.com`, `wss://relay2.com`]
     const pool = RelayPool(relays, {reconnect: false})
     ```
      */
-    constructor(relays: string[], opts: {
+    constructor(relays: string[], opts?: {
         reconnect?: boolean;
-    } | undefined);
+    });
     onfn: {};
     /**
      * @type {Relay[]}
@@ -50,9 +50,9 @@ declare class RelayPool {
     /**
      *
      * @param {unknown} payload
-     * @param {string[] | undefined} relay_ids
+     * @param {string[]} [relay_ids]
      */
-    send(payload: unknown, relay_ids: string[] | undefined): void;
+    send(payload: unknown, relay_ids?: string[]): void;
     setupHandlers(): void;
     /**
      * @param {string} url
@@ -61,15 +61,15 @@ declare class RelayPool {
     /**
      * @param {string} sub_id
      * @param {string | string[]} filters
-     * @param {string[]} relay_ids
+     * @param {string[]} [relay_ids]
      */
-    subscribe(sub_id: string, filters: string | string[], relay_ids: string[]): void;
+    subscribe(sub_id: string, filters: string | string[], relay_ids?: string[]): void;
     /**
      *
      * @param {string} sub_id
-     * @param {string[] | undefined} relay_ids unscubscribe from all relays if undefined
+     * @param {string[]} [relay_ids] unscubscribe from all relays if undefined
      */
-    unsubscribe(sub_id: string, relay_ids: string[] | undefined): void;
+    unsubscribe(sub_id: string, relay_ids?: string[]): void;
     /**
      * @param {Relay | string} relay
      * @returns {boolean} true if relay was added, false if it already exists

--- a/types/lib/relay.d.ts
+++ b/types/lib/relay.d.ts
@@ -1,0 +1,55 @@
+export = Relay;
+/**
+ * @classdesc Connect to a relay server and subscribe to events.
+ * @param {string} relay
+ * @param {{reconnect?: boolean} | undefined} opts
+ * @class Relay
+ */
+declare function Relay(relay: string, opts?: {
+    reconnect?: boolean;
+} | undefined): Relay;
+declare class Relay {
+    /**
+     * @classdesc Connect to a relay server and subscribe to events.
+     * @param {string} relay
+     * @param {{reconnect?: boolean} | undefined} opts
+     * @class Relay
+     */
+    constructor(relay: string, opts?: {
+        reconnect?: boolean;
+    } | undefined);
+    url: string;
+    opts: {
+        reconnect?: boolean;
+    };
+    onfn: {};
+    wait_connected(): Promise<void>;
+    /**
+     *
+     * @param {"message"|"close"|"error"|"open"|"ok"|"event"|"eose"|"notice"} method
+     * @param {(...data: any[]) => unknown} fn
+     * @returns
+     */
+    on(method: "message" | "close" | "error" | "open" | "ok" | "event" | "eose" | "notice", fn: (...data: any[]) => unknown): Relay;
+    close(): void;
+    manualClose: boolean;
+    /**
+     * @param {string} sub_id
+     * @param {string | string[]} filters
+     */
+    subscribe(sub_id: string, filters: string | string[]): void;
+    /**
+     * @param {string} sub_id
+     */
+    unsubscribe(sub_id: string): void;
+    /**
+     *
+     * @param {unknown} data
+     */
+    send(data: unknown): Promise<void>;
+}
+/**
+ *
+ * @param {Relay} me
+ */
+declare function reconnect(me: Relay): Promise<void>;

--- a/types/lib/relay.d.ts
+++ b/types/lib/relay.d.ts
@@ -2,22 +2,22 @@ export = Relay;
 /**
  * @classdesc Connect to a relay server and subscribe to events.
  * @param {string} relay
- * @param {{reconnect?: boolean} | undefined} opts
+ * @param {{reconnect?: boolean}} [opts]
  * @class Relay
  */
 declare function Relay(relay: string, opts?: {
     reconnect?: boolean;
-} | undefined): Relay;
+}): Relay;
 declare class Relay {
     /**
      * @classdesc Connect to a relay server and subscribe to events.
      * @param {string} relay
-     * @param {{reconnect?: boolean} | undefined} opts
+     * @param {{reconnect?: boolean}} [opts]
      * @class Relay
      */
     constructor(relay: string, opts?: {
         reconnect?: boolean;
-    } | undefined);
+    });
     url: string;
     opts: {
         reconnect?: boolean;


### PR DESCRIPTION
This PR adds in-code documentation with JSDoc + TS/Doc typings. 

The typings are automatically updated with `npm run prepublish`. 

Note that it's possible to use something like https://www.npmjs.com/package/jsdoc-to-markdown (or https://www.npmjs.com/package/typedoc-plugin-markdown) to automatically generate the README's `API` section.

